### PR TITLE
Update Kubewarden examples

### DIFF
--- a/tests/allowPrivilegeEscalation/kubewarden.yaml
+++ b/tests/allowPrivilegeEscalation/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: allowprivilegeescalation
 spec:
-  module: ghcr.io/kubewarden/policies/psp-allow-privilege-escalation:v0.1.7
+  module: registry://ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.10
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]
@@ -12,4 +12,4 @@ spec:
       operations:
       - CREATE
       - UPDATE
-  mutating: false
+  mutating: true

--- a/tests/allowedCapabilities/kubewarden.yaml
+++ b/tests/allowedCapabilities/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: allowedcapabilities
 spec:
-  module: registry://ghcr.io/kubewarden/policies/psp-capabilities:v0.1.3
+  module: registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.8
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/allowedFlexVolumes/kubewarden.yaml
+++ b/tests/allowedFlexVolumes/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: allowedflexvolumes
 spec:
-  module: registry://ghcr.io/kubewarden/policies/psp-flexvolume-drivers:v0.0.1
+  module: registry://ghcr.io/kubewarden/policies/flexvolume-drivers-psp:v0.1.1
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/allowedHostPaths/kubewarden.yaml
+++ b/tests/allowedHostPaths/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: allowedhostpaths
 spec:
-  module: ghcr.io/kubewarden/policies/psp-hostpaths:v0.1.2
+  module: registry://ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.4
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/tests/allowedProcMountTypes/kubewarden.yaml
+++ b/tests/allowedProcMountTypes/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: allowedprocmounttypes
 spec:
-  module: ghcr.io/kubewarden/policies/psp-allowed-proc-mount-types:v0.0.2
+  module: registry://ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.1
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/tests/allowedUnsafeSysctls/kubewarden.yaml
+++ b/tests/allowedUnsafeSysctls/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: allowedunsafesysctls
 spec:
-  module: ghcr.io/kubewarden/policies/psp-sysctl:v0.1.4
+  module: registry://ghcr.io/kubewarden/policies/sysctl-psp:v0.1.6
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/tests/apparmor/kubewarden.yaml
+++ b/tests/apparmor/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: apparmor
 spec:
-  module: ghcr.io/kubewarden/policies/psp-apparmor:v0.1.6
+  module: registry://ghcr.io/kubewarden/policies/apparmor-psp:v0.1.8
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/tests/defaultAllowPrivilegeEscalation/kubewarden.yaml
+++ b/tests/defaultAllowPrivilegeEscalation/kubewarden.yaml
@@ -1,9 +1,9 @@
 apiVersion: policies.kubewarden.io/v1alpha2
 kind: ClusterAdmissionPolicy
 metadata:
-  name: defaultaddcapabilities
+  name: defaultallowprivilegeescalationdisabled
 spec:
-  module: registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.8
+  module: registry://ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.10
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]
@@ -14,5 +14,4 @@ spec:
       - UPDATE
   mutating: true
   settings:
-    default_add_capabilities:
-      - something
+    default_allow_privilege_escalation: false

--- a/tests/forbiddenSysctls/kubewarden.yaml
+++ b/tests/forbiddenSysctls/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: forbiddensysctls
 spec:
-  module: ghcr.io/kubewarden/policies/psp-sysctl:v0.1.4
+  module: registry://ghcr.io/kubewarden/policies/sysctl-psp:v0.1.6
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/tests/fsgroup/kubewarden.yaml
+++ b/tests/fsgroup/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: fsgroup
 spec:
-  module: ghcr.io/kubewarden/policies/psp-allowed-fsgroups:v0.0.1
+  module: registry://ghcr.io/kubewarden/policies/allowed-fsgroups-psp:v0.1.1
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/tests/hostIPC/kubewarden.yaml
+++ b/tests/hostIPC/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: hostipc
 spec:
-  module: registry://ghcr.io/kubewarden/policies/psp-host-namespaces:v0.0.9
+  module: registry://ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.1
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/hostNetwork/kubewarden.yaml
+++ b/tests/hostNetwork/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: hostnetwork
 spec:
-  module: registry://ghcr.io/kubewarden/policies/psp-host-namespaces:v0.0.9
+  module: registry://ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.1
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/hostPID/kubewarden.yaml
+++ b/tests/hostPID/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: hostpid
 spec:
-  module: registry://ghcr.io/kubewarden/policies/psp-host-namespaces:v0.0.9
+  module: registry://ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.1
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/hostPorts/kubewarden.yaml
+++ b/tests/hostPorts/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: hostports
 spec:
-  module: registry://ghcr.io/kubewarden/policies/psp-host-namespaces:v0.0.9
+  module: registry://ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.1
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/readOnlyRootFilesystem/kubewarden.yaml
+++ b/tests/readOnlyRootFilesystem/kubewarden.yaml
@@ -4,7 +4,7 @@ metadata:
   name: readonlyrootfilesystem
 spec:
   policyServer: default
-  module: registry://ghcr.io/kubewarden/policies/readonly-root-filesystem-psp-policy:v0.1.0
+  module: registry://ghcr.io/kubewarden/policies/readonly-root-filesystem-psp:v0.1.2
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/requiredDropCapabilities/kubewarden.yaml
+++ b/tests/requiredDropCapabilities/kubewarden.yaml
@@ -3,7 +3,7 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: requireddropcapabilities
 spec:
-  module: ghcr.io/kubewarden/policies/psp-capabilities:v0.1.6
+  module: registry://ghcr.io/kubewarden/policies/capabilities-psp:v0.1.8
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]

--- a/tests/runAsGroup/kubewarden.yaml
+++ b/tests/runAsGroup/kubewarden.yaml
@@ -4,7 +4,7 @@ metadata:
   name: runasgroup
 spec:
   policyServer: default
-  module: registry://ghcr.io/kubewarden/policies/psp-user-group:v0.1.1
+  module: registry://ghcr.io/kubewarden/policies/user-group-psp:v0.1.3
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/runAsUser/kubewarden.yaml
+++ b/tests/runAsUser/kubewarden.yaml
@@ -4,7 +4,7 @@ metadata:
   name: runasuser
 spec:
   policyServer: default
-  module: registry://ghcr.io/kubewarden/policies/psp-user-group:v0.1.1
+  module: registry://ghcr.io/kubewarden/policies/user-group-psp:v0.1.3
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/seLinux/kubewarden.yaml
+++ b/tests/seLinux/kubewarden.yaml
@@ -4,7 +4,7 @@ metadata:
   name: selinux
 spec:
   policyServer: default
-  module: registry://ghcr.io/kubewarden/policies/psp-selinux:v0.0.1
+  module: registry://ghcr.io/kubewarden/policies/selinux-psp:v0.1.1
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/supplementalGroups/kubewarden.yaml
+++ b/tests/supplementalGroups/kubewarden.yaml
@@ -4,7 +4,7 @@ metadata:
   name: supplementalgroups
 spec:
   policyServer: default
-  module: registry://ghcr.io/kubewarden/policies/psp-user-group:v0.1.1
+  module: registry://ghcr.io/kubewarden/policies/user-group-psp:v0.1.3
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/tests/volumes/kubewarden.yaml
+++ b/tests/volumes/kubewarden.yaml
@@ -4,7 +4,7 @@ metadata:
   name: volumes
 spec:
   policyServer: default
-  module: registry://ghcr.io/kubewarden/policies/psp-volumes:v0.1.2
+  module: registry://ghcr.io/kubewarden/policies/volumes-psp:v0.1.4
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]


### PR DESCRIPTION
The PSP policies got renamed to have a naming scheme that is consistent with their GitHub repository.

This commit updates all the Kubewarden example to use the latest versions of the PSP policies.

BTW, old files are still available over our container registry. This change is just to make everything future proof.

Finally, thanks a lot for this awesome repository! :clap: 

